### PR TITLE
MLP example and resuming GHN training

### DIFF
--- a/examples/custom_cnn.py
+++ b/examples/custom_cnn.py
@@ -52,7 +52,7 @@ class CNN(nn.Module):
 
 
 model = CNN().eval()    # Create the net
-model.expected_image_sz = 224 if is_imagenet else 32  # to construct the graph
+model.expected_input_sz = 224 if is_imagenet else 32  # to construct the graph
 model = ghn(model)      # Predict all parameters for the model
 
 print('\nEvaluation of CNN with {} parameters'.format(capacity(model)[1]))

--- a/examples/mlp.ipynb
+++ b/examples/mlp.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "10761ffc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright (c) Facebook, Inc. and its affiliates.\n",
+    "# All rights reserved.\n",
+    "#\n",
+    "# This source code is licensed under the license found in the\n",
+    "# LICENSE file in the root directory of this source tree.\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "from ppuda.ghn.nn import GHN2\n",
+    "from ppuda.deepnets1m.graph import Graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38573384",
+   "metadata": {},
+   "source": [
+    "# Predict parameters for a fully-connected neural network (MLP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e0ec4351",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjwAAAIuCAYAAAC7EdIKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAAmV0lEQVR4nO3debjvc7n/8edr24Zt2CRDxpzKKYpNxhAZk6SihEhRKKHDT8PJadtNp06dkkR1Kk1X83ScJkdJUshQKCUNQsZCh2So7t8fn6VMe++1915rvb/fz/f5uC5/7G398fon16v7vtfnnapCkiSpz6a1DiBJkjTZLDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJKn3LDySJImTDz/51Hce+85ZrXNMFguPJEkj7l3HvGurTS7aZPeVb175pDlz5qR1nskwvXUASZLUzpw5c6Y95qbHvHvzH26+0qo3rrrJHcvecRhwSutcE80JjyRJI2yVG1c5doczd5iVCutctc6M1a5b7Yg5c+Ys1zrXRLPwSJI0oubMmfPINa9d8+A1rltjyfv+buczdl5v9d+t/p6WuSaDhUeSpBG1wi0r7DXrkln/dP+/W+6O5Vju/5bbolWmyWLhkSRpRN224m2nnrPNOZcW9fe/+93qv7v7lhVv+VjDWJPCwiNJ0ghIZ9UkWybZL8knjj/++K1vXvnmf7101qW3AlSKM3c888c3r3rzO1vnnWgWHkmSRsNvgauB/wU+DuwPLHPUCUedftEmF51z9xJ3c8GmF9x888o3Hz179uy/NU06CSw8kiSNho8ABSwHBPhyVX0N4Jq1rzn0G8/4xjWXbXjZmUf/59E/aBlyslh4JEnquSSPBNajKzoF3A0ced+/nz179vXXrH3NG65d69pXNIo46VJV8/8pSZI0lJLsAbwf+CzwSeB84O1V9fqmwaaYX1qWJKmHkjwCeA+wNbBPVZ099vebA5e3zNaCKy1JknomyTOAy4DbgVn3lR2Aqrq4qu5qFq4RJzySJPVEkpnAu4CdgAOr6tuNIw0MJzySJPVAkp3opjp/Aza07DyQEx5JkoZYkmWB/wCeBby0qk5vHGkgOeGRJGlIJdkOuBRYGtjAsjN3TngkSRoySZYG3go8H3h5VZ3WONLAc8IjSdIQSbIV8GNgZbpbHcvOODjhkSRpCCRZCngT3RtYr6yqLzaONFQsPJIkDbgkmwEfo/tg4KyquqlxpKFj4ZEkaUAlWRJ4A/BS4Cjgs+WbUAvFwiNJ0gBKsjHdVOc3dFOdGxpHGmoeLUuSNECSLJ5kNnA68E7gOZadReeER5KkAZFkA7qpzo3Ak6vq2saResMJjyRJjSWZnuR1wJnA+4DdLDsTywmPJEkNJVkP+Cjdy+abVtVv2ybqJyc8kiQ1kGSxJMcA36NbY+1i2Zk8TngkSZpiSdYFTgX+CmxeVb9uHKn3nPBIkjRFkkxLciRwLvB5YHvLztRwwiNJ0hRI8k/AR4Alga2q6heNI40UJzySJE2idA4DLgC+DjzVsjP1nPBIkjRJkqwNfBhYHti2qi5vHGlkOeGRJGmCjU11DgIuAs6iW2FZdhpywiNJ0gRKsjrwX8DqwI5VdWnjSMIJjyRJE2JsqrM/8GO6e50tLDuDwwmPJEmLKMmqwAeAxwK7VtXFjSPpQZzwSJK0CJLsDVwCXE73NIRlZwA54ZEkaSEkWQk4GdgQeHZVnd84kubBCY8kSQsoyXOBy4CrgY0tO4PPCY8kSeOUZEXgRGBL4PlVdU7jSBonJzySJI1DkmfSTXVuAWZZdoaLEx5JkuYhyfLAu4HtgRdW1VltE2lhOOGRJGkukuxCN9W5G9jQsjO8nPBIkvQgSZYD3gHsBhxcVWc0jqRF5IRHkqT7SbI9cCmwOLCBZacfnPBIkgQkWQZ4G/Bc4NCq+lrjSJpATngkSSMvyTZ0X0tege5Wx7LTM054JEkjK8kM4M3AfsArqurLjSNpkjjhkSSNpCRbAD8C1qS71bHs9JgTHknSSEmyJHA8cBBwRFV9rm0iTQULjyRpZCTZBPgYcCXdrc6NjSNpirjSkiT1XpIlkswBvgH8O7CnZWe0OOGRJPVaklnAR4HrgI2q6rq2idSCEx5JUi8lmZ7kOOBbdC+c727ZGV1OeCRJvZNkfbpbnVuBTarq6saR1JgTHklSbyRZLMmrgbOBDwFPt+wInPBIknoiyT/TTXXuAjarqt80jqQB4oRHkjTUkkxL8irgB8CngB0tO3owJzySpKGV5LHAqXT/B37Lqvpl40gaUE54JElDZ2yq8wrgfOArwHaWHc2LEx5J0lBJ8mjgw8BywDZV9fPGkTQEnPBIkoZCOi8FLqT7ts7Wlh2NlxMeSdLAS7Im3a+ZrwxsX1U/aRxJQ8YJjyRpYI1NdQ4EfkT3W1hbWna0MJzwSJIGUpJHAR8E1gF2qaoftU2kYeaER5I0UMamOvsClwCXAptadrSonPBIkgZGklWAk4H16R77vKBxJPWEEx5J0kBIshfdVOfXwJMtO5pITngkSU0leSTwXmBTYK+q+kHjSOohJzySpGaSPIvuTudGYCPLjiaLEx5J0pRLsgJwAvBUYN+qOrtpIPWeEx5J0pRKsitwGfAnYJZlR1PBCY8kaUokmQn8J7AL8JKq+lbjSBohTngkSZMuyY50tzoAG1h2NNWc8EiSJk2SZYG3A3sAh1TVNxpH0ohywiNJmhRJtqX7rs6ywIaWHbXkhEeSNKGSLA28BXgBcFhVndY4kuSER5I0cZI8he5l80fR3epYdjQQnPBIkhZZkqWAOcCBwCur6guNI0kPYOGRJC2SJJsCHwN+Tnerc1PjSNJDWHgkSQslyRLAvwGHAK8CPlNV1TSUNBcWHknSAkuyEd1U52q6N7Cub5tImjePliVJ45Zk8SRvAM4A3gXsYdnRMHDCI0kalyRPopvq3AxsXFXXNo4kjZsTHknSPCWZnuS1wHeA9wPPsOxo2DjhkSTNVZInAB+le9l806r6bdtE0sJxwiNJeogkiyU5GjgH+ASws2VHw8wJjyTpAZI8DjgVKGCLqvpV40jSInPCI0kCIMm0JEcA5wFfBJ5m2VFfOOGRJJFkHeAjwAxg66q6om0iaWI54ZGkEZbOIcAFwDeBbSw76iMnPJI0opKsBXwYWJFuffXTxpGkSeOER5JGzNhU5yXAxcDZwFMsO+o7JzySNEKSrA58EFgT2KmqLmkcSZoSTngkaQSMTXVeCPyYbrKzuWVHo8QJjyT1XJJVgVOAf6Z7FuKixpGkKeeER5J6LMnzgUuAXwCbWHY0qpzwSFIPJVkJOAnYCHhOVZ3XNpHUlhMeSeqZJM8BLgV+B2xs2ZGc8EhSbyR5BHAi8BTgBVX1vcaRpIHhhEeSeiDJbsBlwG3ALMuO9EBOeCRpiCVZHngXsAPwoqo6s3EkaSA54ZGkIZVkZ7pbnb8AG1p2pLmz8EjSgEtmvi9ZbK9//DnLJXk/3evmh1TVoVV1e7uE0uBLVbXOIEmaiyRPgCUvhcX/AHesBWwCfBr4LvAvVXVb04DSkLDwSNIAS5b/EtOPfRZ//epd1A+PgLoX+GNVfbV1NmmYWHgkaUB1053lLmapa2fwt4vhnmfdAHesVVV/aZ1NGjbe8EjSwJr5Vqa/enEyExZ7GuSJy0L2b51KGkZOeCRpAD1gupOZ3V/+9SynPNJCcsIjSQPpftOd+zjlkRaaEx5JGjBJNoBcCqveQ5a66wH/sm5bEu6+surODRrFk4aSX1qWpAGRZENgNrA7FHDD2yi+8DA/+oepTSYNPyc8kjQAkhwGnEzXdKYB9wCPraprmwaTesIbHkkaDF8CfnS/P98J/K5RFql3LDySNBhuBq4Efgn8FbioHMFLE8YbHkkaDEcD6wIbAc8GbmmaRuoZb3gkqbEkOwGfBLaoqt+2ziP1kSstSWooyTp0ZWdfy440eSw8ktRIkqWBLwNvr6rvtM4j9ZkrLUlqIEmAT4z98QAPlKXJ5dGyJLXxKuCJwNaWHWnyOeGRpCmWZAfgU8CWVXVV4zjSSPCGR5KmUJJH05WdF1p2pKlj4ZGkKZJkBt0Xld9RVd9unUcaJa60JGkKjB0pfxxYjG664398pSnk0bIkTY0jgA2ArSw70tRzwiNJkyzJ04DP0h0p/6ZtGmk0ecMjSZMoydrAp4H9LTtSOxYeSZok9ztSfndVndE6jzTKXGlJ0iQYO1I+FZgB7OPdjtSWR8uSNDkOB54MPMWyI7XnhEeSJliSbYHP0/1G1q9a55HkDY8kTagkawKfAV5k2ZEGh4VHkiZIkqXojpRPrKrTW+eR9A+utCRpAowdKX8YWA7Y27sdabB4tCxJE+MwYHO6jwtadqQB44RHkhZRkm3oVllbVdUvW+eR9FDe8EjSIkiyBvA54EDLjjS4LDyStJCSLAl8ETipqr7ROo+kuXOlJUkLYexI+YPAisDzvNuRBptHy5K0cA4BtsIjZWkoOOGRpAWUZCvgK8DWVXVl4ziSxsEbHklaAElWpztSfollRxoeFh5JGqexI+UvAB+oqq+1ziNp/FxpSdI4JXk/sCqwV1X9rXUeSePn0bIkjUOSlwHbAVtYdqTh44RHkuYjyZbAacBTq+qK1nkkLThveCRpHpKsRne3c7BlRxpeFh5JmoskSwCfB/6rqv6ndR5JC8+VliTNRZKTgTWA53q3Iw03j5Yl6WEkORjYAY+UpV5wwiNJD5Jkc+BrdEfKP2+dR9Ki84ZHku4nyaPoXkB/qWVH6g8LjySNud+R8keq6r9b55E0cVxpSdKYJO8F1gGe7d2O1C8eLUsSkOTFwNOBzS07Uv844ZE08pJsBnwd2K6qLm+dR9LE84ZH0khLsgrdkfKhlh2pv5zwSBpZSRYHzgDOqarjWueRNHksPJJGVpL3AI8D9qiqv7bOI2nyeLQsaSQleRGwG7CZZUfqPyc8kkZOkk2AbwLbV9VPWueRNPk8WpY0UpKsTHekfJhlRxodTngkjYwk0+mOlM+tqn9tnUfS1LHwSBoZSd4FrAfs7t2ONFo8WpY0EpK8ENgDj5SlkeSER1LvJdkY+F9gh6q6rHUeSVPPo2VJvZZkJeBLwOGWHWl0OeGR1FtjR8qnAxdU1Wtb55HUjhMeSX32NuAvwOtbB5HUlkfLknopyb7AnsCmHilLcqUlqXeSzAK+BexUVZe0ziOpPVdaknolySOBLwNHWHYk3ccJj6TeGDtS/gbw46o6tnUeSYPDCY+kPnkLEOB1rYNIGiweLUvqhSQvAPamO1L+S+s8kgaLKy1JQy/JhsC3gZ2r6seN40gaQK60JA21JCvSHSkfZdmRNDdOeCQNrSSLAV8HflJVx7TOI2lwOeGRNMzeTHeL+JrWQSQNNo+WJQ2lJM8H9gU280hZ0vy40pI0dJI8CfgO8PSqurh1HkmDz5WWpKGS5BHAV4CjLTuSxssJj6ShMXak/D/AL6rqVY3jSBoiTngkDZM3AjMAn42QtEA8WpY0FJLsBexPd6R8b+s8koaLKy1JAy/JE4GzgGdU1YWN40gaQq60JA20JCvQfUn5GMuOpIXlhEfSwEoyje5I+VdVdWTrPJKGlxMeSYPseGA5wGcjJC0Sj5YlDaQkzwFejEfKkiaAKy1JAyfJesDZwG5VdUHrPJKGnystSQMlyfJ0X1J+tWVH0kRxwiNpYIwdKX8FuKaqDm8cR1KPeMMjaZC8AXgE8LzWQST1i4VH0kBIsgdwMN2R8j2t80jqF1dakppL8gS6I+VnVdX5rfNI6h+PliU1lWQm3ZeUX2fZkTRZnPBIambsSPlLwPVV9fLWeST1lzc8klp6PbAysHfrIJL6zcIjqYkkuwOH4pGypCngSkvSlEvyz8A5wLOr6tzWeST1n0fLkqZUkuXoPi54nGVH0lRxwiNpyowdKX8BuLmqDm2dR9Lo8IZH0lR6HbAasG/rIJJGi4VH0pRIshvwCroj5btb55E0WlxpSZp0SdYFvg88t6q+3zqPpNHj0bKkSXW/I+U3WHYkteKER9KkSRLg88BtwMvK/+BIasQbHkmT6TXAWsD+lh1JLVl4JE2KJLsCR9IdKd/VOo+k0eZKS9KES/JY4AfA86rqe63zSJJHy5ImVJJl6Y6U32jZkTQonPBImjBjR8qfAf4EHOzdjqRB4Q2PpIl0LPAY4KmWHUmDxMIjaUIk2QV4FbCFR8qSBo0rLUmLLMljgHOB51fV2a3zSNKDebQsaZEkWQb4MvBmy46kQeWER9JCGztS/hRwD/Bi73YkDSonPJLG7a3/+tbHnXz4yS+8318dA6wLHGbZkTTInPBIGpc5c+bk0Vc9+tsz/2/mGpdteNkWxx9//KbAJ+iOlK9unU+S5sXf0pI0Lo/8/SMP2PqcrTdb/frVl71x+RtPAbYH9rHsSBoGrrQkzdecOXOWXvWGVY9d95frLrvMn5Zh1s9nbb/XznsdWVVntc4mSeNh4ZE0X6tdt9o7dzljlyfe9+ctz9ty1T1W2+OoOXPmpGUuSRovC4+keZozZ86MVW5cZdfl/7j838vNtJrGJhdusvGMO2fs0jKbJI2XhUfSPM2ePfvPf1jpDz++a6l/fDy5KC7b8LIr/7z0n89ql0ySxs/CI2m+rl3r2sO+vcO3f3Xfny9f//I/3rTKTXNmz559d8tckjReFh5J8zV79uybrn701R+/4VE33Hvv4vdy/hbnn3fke478UutckjRe/lq6pHlKsjPwpSWWWGLnmc+fuccqN66y8nVrXHdI61yStCAsPJIeVpKVgZOBZwPT77nnnt/fvPLN/+/25W7f6bg3Hee3dyQNFb+0LOkhkmwPnAYsMfbPvcDKVfXHpsEkaSF5wyPp4fzf2D+Ljf152tifJWkoWXgkPURVXQQcBNwB3A3c7uOgkoaZNzySHiLJEsAJwIHAZcBmTQNJ0iKy8Eh6OEcDvwJOG5vs/LpxHklaJB4tS3qAJGsDFwObV5VFR1IveMMj6cFOAE607EjqE1dakv4uyTOADYD9WmeRpIlk4ZEEQJIZwEnA4VV11/x+XpKGiSstSfd5DfCjqvpm6yCSNNE8WpZEkscC5wMbV9U1rfNI0kRzwiONuCQB3gv8h2VHUl9ZeCQ9B1iH7rezJKmXXGlJIyzJMsDlwIFVdVbjOJI0aZzwSKPtOOAcy46kvnPCI42oJOsBZwMbVtX1rfNI0mRywiONoLFD5fcBb7LsSBoFFh5pNO0DPAI4uXUQSZoKrrSkEZNkJvAz4HlVdW7rPJI0FSw80ohJ8m5gZlUd3DqLJE0V39KSRkiSWcALgSe2ziJJU8kbHmlEJJlGd7NzXFXd3DqPJE0lC480Og6km+p+qHUQSZpq3vBIIyDJinRfVH5mVV3UOo8kTTULjzQCkpwC/K2qDm+dRZJa8GhZ6rkkm9E9ELp+4yiS1Iw3PFKPJVkMOAV4bVXd2jqPJLVi4ZH67RDgTuDjrYNIUkve8Eg9lWQV4CfAjlV1Wes8ktSShUfqqSSnArdU1TGts0hSax4tSz2UZGtgZ2C91lkkaRB4wyP1TJLpdIfKx1TV7a3zSNIgsPBI/XMEcCPwudZBJGlQeMMj9UiS1YFLga2r6orWeSRpUFh4pB5J8mng11X1+tZZJGmQeLQs9USSHYGnAAe3ziJJg8YbHqkHkiwBnAQcVVV3ts4jSYPGwiP1w9HAr4DTWgeRpEHkDY805JI8GrgY2Kyqft06jyQNIic80vA7ATjBsiNJc+fRsjTEkuwGPAnYt3UWSRpkFh5pSCWZAbwXeEVV3dU6jyQNMlda0vB6DfCjqjq9dRBJGnQeLUtDKMnjgPOAjavqmtZ5JGnQOeGRhkyS0K2y/sOyI0njY+GRhs9zgbXpfjtLkjQOrrSkIZJkGeBy4MCqOqtxHEkaGhYeaYgkeRuwZlXt3zqLJA0TC480JJKsD3wX2KCqbmidR5KGiTc80hAYO1R+H/Amy44kLTgLjzQc9gVWAE5unEOShpIrLWnAJVke+BmwV1Wd2zqPJA0jC4804JKcACxbVS9tnUWShpVvaUkDLMksunXWE1tnkaRh5g2PNKCSTKO72fm3qvp96zySNMwsPNLgejHdFPZDjXNI0tDzhkcaQElWpDtU3q2qLmqdR5KGnYVHGkBJ3g/8pape2TqLJPWBR8vSgEmyGfBsYL3WWSSpL7zhkQZIksWAU4DXVNVtjeNIUm9YeKTBcihwJ/CJ1kEkqU+84ZEGRJJVgJ8CO1TVZa3zSFKfWHikAZHko8Dvq+r/tc4iSX3j0bI0AJJsA+wIrN86iyT1kTc8UmNJptN9UfmYqrq9dR5J6iMLj9TeEcCNwOdbB5GkvvKGR2ooyRrAJcDWVXVF6zyS1FcWHqmhJJ8BflVVr2+dRZL6zKNlqZEkOwJbAAe1ziJJfecNj9RAkiWB9wFHVdWdrfNIUt9ZeKQ2jgaurKrTWgeRpFHgDY80xZKsA1wEbFpVv2kcR5JGghMeaeqdAJxg2ZGkqePRsjSFkjyT7mvK+7TOIkmjxJWWNEWSzKB7HPSwqvrf1nkkaZS40pKmzmuBiyw7kjT1nPBIUyDJusC5wEZVdW3rPJI0apzwSJMsSYD3Am+37EhSGxYeafLtCaxF99tZkqQGXGlJkyjJssDlwAFV9d3WeSRpVFl4pEmU5O3A6lV1QOsskjTKLDzSJEmyPvBdYIOquqF1HkkaZd7wSJNg7FD5ZOCNlh1Jas/CI02O/YCZwCmtg0iSXGlJEy7J8sDPgD2r6rzWeSRJFh5pwiV5D7B0Vb2sdRZJUsfHQ6UJlGQjuodBn9g4iiTpfrzhkSZIkml0h8rHVdXvW+eRJP2DhUeaOC+h+9/Uh1sHkSQ9kDc80gRI8ki6LyrvWlU/ap1HkvRAFh5pAiT5AHBPVR3ROosk6aE8WpYWUZLNgWcB67fOIkl6eN7wSIsgyWJ0Hxd8TVXd1jiOJGkuLDzSojkMuAP4ZOsgkqS584ZHWkhJVgV+Ajytqn7aOo8kae4sPNJCSvIx4KaqOrZ1FknSvHm0LC2EJE8FdgDWa51FkjR/3vBICyjJ4nRfVD66qu5onUeSNH8WHmnBHQFcD3yhdRBJ0vh4wyMtgCRrAJcAW1XVL1rnkSSNj4VHWgBJPgv8oqr+rXUWSdL4ebQsjVOSnYDN6R4JlSQNEW94pHFIsiTwPuDIqrqzdR5J0oKx8EjjcwxwRVX9T+sgkqQF5w2PNB9J1gEuBDarqt80jiNJWghOeKT5ew/wbsuOJA0vj5aleUiyO/AEYO/WWSRJC8+VljQXSWYAPwUOraozWueRJC08V1rS3L0OuNCyI0nDzwmP9DCSrAucC8yqqt+1ziNJWjROeKQHSRLgJODfLTuS1A8eLUtjkiVeDktvBHwTWAM4sW0iSdJEcaUlAUmWgRnXAUvCn18E/KyqLmudS5I0MVxpSQBMfwXTdliM6a9eDGbuadmRpH5xwqOR9/fpzpLnzSRrw11r/Rnu2LCqftk6myRpYjjhke6b7kzbELICTD9mcZj55tapJEkTxwmPRtoDpjvTNuz+sm5zyiNJPeOERyMnycwk2yaZDdPO+ft05+8/sIJTHknqGSc8GhlJdgE+CqwE3AssDUve032dYal7H/jT9y4Gt0+HmllVf57qrJKkieV3eDRKrgSWBxYf++duuHtHuPsa+NPD/fxdlh1J6gcLj0bJn4BfABsCAb5XVd9vG0mSNBW84dFISLI1cBHwdbovKAd4bdNQkqQp44RHvTb2Ltar6MrNQVX1tSTTgW9W1UVNw0mSpoxHy+qtJMsDHwHWBp5fVVe1TSRJasWVlnopySzgQuAGYBvLjiSNNguPeifJS4BvAbOr6vCqurt1JklSW97wqDeSzABOAp4CbFtVP2scSZI0IJzwqBeSrAucBywFbG7ZkSTdn4VHQy/JnsD3gfcD+1fVHY0jSZIGjCstDa0kiwNvB54L7FZVFzaOJEkaUBYeDaUkawCfA24FNqmqWxpHkiQNMFdaGjpJdqL7lfOvAntYdiRJ8+OER0MjyTTgOOAwYL+q+k7jSJKkIWHh0VBIshLwSWAG3Qrr+saRJElDxJWWBl6SLeke/rwE2NGyI0laUE54NLDGHv58Jd0a62VVdVrjSJKkIWXh0UBKMhP4EPBY4ClV9evGkSRJQ8yVlgZOkg2AC+h+5Xxry44kaVFZeDRQkhwAnAm8paoOraq7WmeSJA0/V1oaCEmWAk4EtgO2r6qfNI4kSeoRJzxqLsljgB8AywObWnYkSRPNwqOmkuxB98r5qcA+VXV740iSpB5ypaUmkkwH3gLsQ/c8xHmNI0mSeszCoymXZDXgs8CddF9N/n3jSJKknnOlpSmVZHu6ryafAexm2ZEkTQUnPJoSYw9/vhY4Ajigqr7VOJIkaYRYeDTpkqwIfBx4BLBZVV3bOJIkacS40tKkSrIZ3QrrCuBplh1JUgtOeDQpxh7+fDlwPHBYVX2pbSJJ0iiz8GjCJVkW+ADwJLq3sK5sHEmSNOJcaWlCJVkf+CFwF7ClZUeSNAgsPJowSfYDvgu8s6oOrqo/t84kSRK40tIESLIk8G5gZ2CnqrqkcSRJkh7ACY8WSZJ1gHOAVeke/rTsSJIGjoVHCy3JM4HzgU8Bz6uqPzaOJEnSw3KlpQU29vDnG4EDgD2r6vuNI0mSNE8WHi2QJI8CPg38he7hz5saR5Ikab5caWnckmwLXAicDexq2ZEkDQsnPJqvsa8mHwscDby4qr7ZOJIkSQvEwqN5SrIC8DG638LavKqubptIkqQF50pLc5XkyXQPf14FbGvZkSQNKwuPHiKdQ4DTgddV1VFVdU/rXJIkLSxXWnqAJMsApwBPBrapqisaR5IkaZE54dHfJXk83YcEAbaw7EiS+sLCIwCS7E33RMR7gAOr6k+NI0mSNGFcaY24JEsA7wB2B55eVRc3jiRJ0oSz8IywJGsDnwNupHv489bGkSRJmhSutEZUkl2BHwJfBJ5j2ZEk9ZkTnhGTZDFgNnAwsHdVnd04kiRJk87CM0KSrAJ8CliM7uHPGxpHkiRpSrjSGhFJtqb7avL5wM6WHUnSKHHC03NjD3/+C/Aa4KCq+lrjSJIkTTkLT48lWR44FViL7kOCV7VNJElSG660eirJLOBC4Hq6JyKuaptIkqR2LDw9lOQg4FvA7Ko6vKrubp1JkqSWXGn1SJKlgZOALYHtquryxpEkSRoITnh6Ism6wLnAUsDmlh1Jkv7BwtMDSfYEvg+8H3hhVd3ROJIkSQPFldYQS7I48HbgucAzq+qCxpEkSRpIFp4hlWRN4LPArXRfTb6lcSRJkgaWK60hlGRn4ALgq8Aelh1JkubNCc8QSTINOA44DNivqr7TOJIkSUPBwjMkkqwEfBJYGti0qq5rHEmSpKHhSmsIJNmS7uHPS4AdLDuSJC0YJzwDbOzhz1cC/wa8rKr+u3EkSZKGkoVnQCWZCXwIeBywZVX9unEkSZKGliutAZRkA7rfwroV2MqyI0nSorHwDJgkBwBnAm+pqkOr6q7WmSRJGnautAZEkqWAE4Ht6A6TL2scSZKk3nDCMwCSPAb4AbA83a+cW3YkSZpAFp7GkjwbOA84Fdinqm5vHEmSpN5xpdVIkunAW4EX0D0PcV7jSJIk9ZaFp4Ekq9E9/Hkn3cOfv28cSZKkXnOlNcWSbE/31eQzgN0sO5IkTT4nPFNk7OHP1wJHAC+qqjMaR5IkaWRYeKZAkhWBjwOPADarqmsbR5IkaaS40ppkSTajW2FdATzNsiNJ0tRzwjNJxh7+fDlwPPDyqvpi20SSJI0uC88kSLIs8AHgScDWVXVl40iSJI00V1oTLMn6wA+Bu+leObfsSJLUmIVnAiXZD/gu8M6qOqiq/tw6kyRJcqU1IZIsCbwb2BnYqaouaRxJkiTdjxOeRZRkHeAcYFW6hz8tO5IkDRgLzyJI8kzgfOBTwPOq6o+NI0mSpIfhSmshjD38+UbgAGDPqvp+40iSJGkeLDwLKMmjgE8Df6F7+POmxpEkSdJ8uNJaAEm2BS4EzgZ2texIkjQcnPCMw9hXk48FjgZeXFXfbBxJkiQtAAvPfCRZAfgY3W9hbV5VV7dNJEmSFpQrrXlI8mS6hz+vAra17EiSNJwsPA8jnUOA04HXVdVRVXVP61ySJGnhuNJ6kCTLAKcATwa2qaorGkeSJEmLyAnP/SR5PN2HBAG2sOxIktQPFp4xSfameyLiRODAqvpT40iSJGmCjPxKK8kSwDuA3YGnV9XFjSNJkqQJNtKFJ8nawOeAG+ke/ry1cSRJkjQJRnallWRX4IfAF4HnWHYkSeqv3kx4xn6NfL9x/vjtdL+FtXdVnT15qSRJ0iBIVbXOMCGSnLUsbPf4+fzcFcAdcBuwXlXdMPnJJElSa72Z8AA8HvjgfH7mEOAiuNSyI0nS6BjVG55+jLUkSdK4jGrhkSRJI8TCI0mSes/CI0mSes/CI0mSes/CI0mSes/CI0mSeq9X3+G5gu47O/P7GUmSNFr6VHg+dQdw0Th/dlKTSJKkgdKbpyUkSZLmxhseSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUexYeSZLUe/8fVAmfAq+YP5UAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 720x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MLP(\n",
+      "  (layers): Sequential(\n",
+      "    (0): Linear(in_features=1000000, out_features=64, bias=True)\n",
+      "    (1): ReLU()\n",
+      "    (2): Linear(in_features=64, out_features=2, bias=True)\n",
+      "  )\n",
+      ")\n",
+      "WARNING: unrecognized shape torch.Size([64, 1000000]), so the closest shape at index [64, 8192, 1, 1] will be used instead.\n",
+      "number of parameter tensors predicted using GHN: 4, total parameters predicted: 64000194 (MATCHED!), time to predict (on CUDA:0): 0.2748 sec\n",
+      "predictions:\n",
+      " tensor([[9.5539, 8.7456],\n",
+      "        [9.5420, 8.7253],\n",
+      "        [9.5402, 8.7330],\n",
+      "        [9.5495, 8.7399],\n",
+      "        [9.5667, 8.7562]], grad_fn=<AddmmBackward>)\n",
+      "\n",
+      "done\n"
+     ]
+    }
+   ],
+   "source": [
+    "ghn = GHN2('imagenet')  # load GHN2 trained on ImageNet\n",
+    "\n",
+    "in_features = 1000000   # assume we have tabular data with 100000 features\n",
+    "num_classes = 2         # assume we want to solve a binary classification task for these data\n",
+    "\n",
+    "# Define the network configuration\n",
+    "class MLP(nn.Module):\n",
+    "    def __init__(self, in_features, num_classes, C=64):\n",
+    "        super(MLP, self).__init__()\n",
+    "        self.in_features = in_features\n",
+    "        self.layers = nn.Sequential(nn.Linear(in_features, C),\n",
+    "                                    nn.ReLU(),\n",
+    "                                    nn.Linear(C, num_classes)\n",
+    "                                    )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.layers(x)\n",
+    "\n",
+    "model = MLP(in_features=in_features, num_classes=num_classes).eval()    # Create the net\n",
+    "model.expected_input_sz = (in_features,)\n",
+    "Graph(model).visualize()\n",
+    "print(model)\n",
+    "model = ghn(model)      # Predict all parameters for the model\n",
+    "\n",
+    "# Make predictions using the predicted parameters on 5 samples\n",
+    "model.to('cpu')\n",
+    "n_samples = 5\n",
+    "x = torch.rand(n_samples, in_features)  # generate random input\n",
+    "print('predictions:\\n', model(x))  \n",
+    "# Note: since GHN2 was trained on ImageNet, these predictions will be meaningless\n",
+    "# But predicted parameters may be useful as a starting point depending on the task\n",
+    "\n",
+    "print('\\ndone')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:ghntmp]",
+   "language": "python",
+   "name": "conda-env-ghntmp-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ppuda/config.py
+++ b/ppuda/config.py
@@ -65,6 +65,8 @@ def init_config(mode='eval'):
                         help='number of cpu processes to use')
     parser.add_argument('--device', type=str, default=default_device(), help='device: cpu or cuda')
     parser.add_argument('--debug', type=int, default=1, help='the level of details printed out, 0 is the minimal level.')
+    parser.add_argument('--ckpt', type=str, default=None,
+                        help='path to load the network/GHN parameters from')
 
     is_train_ghn = mode == 'train_ghn'
     is_train_net = mode == 'train_net'
@@ -80,8 +82,6 @@ def init_config(mode='eval'):
                             help='one of the architectures: '
                                  'string for the predefined genotypes such as DARTS; '
                                  'the architecture index from DeepNets-1M')
-        parser.add_argument('--ckpt', type=str, default=None,
-                            help='path to load the network/GHN parameters from')
         parser.add_argument('--noise', action='store_true', help='add noise to validation/test images')
         if is_train_net:
             parser.add_argument('--pretrained', action='store_true', help='use pretrained torchvision.models')

--- a/ppuda/deepnets1m/net.py
+++ b/ppuda/deepnets1m/net.py
@@ -190,7 +190,7 @@ class Network(nn.Module):
         self.genotype = genotype
         self._auxiliary = auxiliary
         self.drop_path_prob = 0
-        self.expected_image_sz = 224 if is_imagenet_input else 32
+        self.expected_input_sz = 224 if is_imagenet_input else 32
 
         self._is_vit = sum([n[0] == 'msa' for n in genotype.normal + genotype.reduce]) > 0 if is_vit is None else is_vit
 
@@ -314,7 +314,7 @@ class Network(nn.Module):
             s0, s1 = s1, cell(s0, s1, self.drop_path_prob)
             if self._auxiliary and cell_ind == self._auxiliary_cell_ind and self.training:
                 logits_aux = self.auxiliary_head(F.adaptive_avg_pool2d(s1, 8)
-                                                 if self._is_vit and self.expected_image_sz == 32
+                                                 if self._is_vit and self.expected_input_sz == 32
                                                  else s1)
         if s1 is None:
             raise ValueError('the network has invalid configuration: the output is None')

--- a/ppuda/utils/trainer.py
+++ b/ppuda/utils/trainer.py
@@ -98,7 +98,7 @@ class Trainer():
         loss = loss / len(logits)         # mean loss across models
 
         if torch.isnan(loss):
-            raise RuntimeError('the loss is {}, unable to proceed'.format(loss))
+            raise RuntimeError('the loss is {}, unable to proceed. This issue can often be fixed by restarting the script and loading the saved checkpoint using the --ckpt argument.'.format(loss))
 
         if self.amp:
             # Scales the loss, and calls backward()

--- a/ppuda/utils/utils.py
+++ b/ppuda/utils/utils.py
@@ -105,7 +105,7 @@ def adjust_net(net, large_input=False):
     :param large_input: True if the input images are large (224x224 or more).
     :return: the adjusted network
     """
-    net.expected_image_sz = 224 if large_input else 32
+    net.expected_input_sz = 224 if large_input else 32
 
     if large_input:
         return net


### PR DESCRIPTION
- Added support of graph construction for MLP in `ppuda/deepnets1m/graph.py`
- Added an example to predict parameters for MLP in `examples/mlp.ipynb`
- Renamed `expected_image_sz` to `expected_input_sz` in the code for more general semantics
- Added support of resuming GHN training after the script crashes in `experiments/train_ghn.py` using the `--ckpt` argument