### PR TITLE
Improved fine-tuning, ConvNeXt support, improved training speed of GHNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,12 @@ The parameters predicted by GHN-2 trained on ImageNet can be fine-tuned on any v
 According to the report ([Pretraining a Neural Network before Knowing Its Architecture](https://arxiv.org/abs/2207.10049)) showing improved fine-tuning results, the following arguments are added to the code: `--opt`, `--init`, `--imsize`, `--beta`, `--layer`.
 
 - For example, to obtain fine-tuning results of `GHN-orth` for **ResNet-50**:
-`python experiments/sgd/train_net.py --split predefined --arch 0 --epochs 300 -d cifar10 --n_shots 100 --lr 0.01 --wd 0.01 --ckpt ./checkpoints/ghn2_imagenet.pt --opt sgd --init orth --imsize 32 --beta 3e-5 --layer 37`
+`python experiments/sgd/train_net.py --val --split predefined --arch 0 --epochs 300 -d cifar10 --n_shots 100 --lr 0.01 --wd 0.01 --ckpt ./checkpoints/ghn2_imagenet.pt --opt sgd --init orth --imsize 32 --beta 3e-5 --layer 37`
 
 - For **[ConvNeXt-Base](https://arxiv.org/abs/2201.03545)**:
-`python experiments/sgd/train_net.py --arch convnext_base --epochs 300 -d cifar10 --n_shots 100 --lr 0.001 --wd 0.1 --ckpt ./checkpoints/ghn2_imagenet.pt --opt adamw --init orth --imsize 32 --beta 3e-5 --layer 94`.
-Multiple warnings will be printed that some layers of ConvNeXt are not supported by GHNs, which is intended.
+`python experiments/sgd/train_net.py --val --arch convnext_base -b 48 --epochs 300 -d cifar10 --n_shots 100 --lr 0.001 --wd 0.1 --ckpt ./checkpoints/ghn2_imagenet.pt --opt adamw --init orth --imsize 32 --beta 3e-5 --layer 94`.
+Multiple warnings will be printed that some layers of ConvNeXt are not supported by GHNs, which is intended. Note that in the report, layer 100 is mistakenly specified as the best value, however 94 should be used for better performance.
+
 
 Below are the commands to reproduce the original (NeurIPS 2021) results.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ authors: [Boris Knyazev](http://bknyaz.github.io/), [Michal Drozdzal](https://sc
 
 
 **Updates**
+- [Jul 21, 2022] Fine-tuning of predicted parameters is improved and parameter prediction for [ConvNeXt](https://arxiv.org/abs/2201.03545) is added (see [report](https://arxiv.org/abs/2207.10049) and respective code changes in [PR#7](https://github.com/facebookresearch/ppuda/pull/7)) 
+- [Jul 21, 2022] Training speed of GHNs is further improved (see [PR#7](https://github.com/facebookresearch/ppuda/pull/7) for details).
 - [Jan 12, 2022] Training speed of GHNs is improved significantly in some cases (see [PR#2](https://github.com/facebookresearch/ppuda/pull/2) for details).
 - [Nov 24, 2021] Video of Yannic Kilcher reviewing our paper together with Boris Knyazev is available on [YouTube](https://youtu.be/3HUK2UWzlFA)
 
@@ -221,6 +223,19 @@ where `$split` is one from `val, test, wide, deep, dense, bnfree, predefined`, `
 
 The parameters predicted by GHN-2 trained on ImageNet can be fine-tuned on any vision dataset, such as CIFAR-10.
 
+
+**[Update Jul 21, 2022]**
+
+According to the report ([Pretraining a Neural Network before Knowing Its Architecture](https://arxiv.org/abs/2207.10049)) showing improved fine-tuning results, the following arguments are added to the code: `--opt`, `--init`, `--imsize`, `--beta`, `--layer`.
+
+- For example, to obtain fine-tuning results of `GHN-orth` for **ResNet-50**:
+`python experiments/sgd/train_net.py --split predefined --arch 0 --epochs 300 -d cifar10 --n_shots 100 --lr 0.01 --wd 0.01 --ckpt ./checkpoints/ghn2_imagenet.pt --opt sgd --init orth --imsize 32 --beta 3e-5 --layer 37`
+
+- For **[ConvNeXt-Base](https://arxiv.org/abs/2201.03545)**:
+`python experiments/sgd/train_net.py --arch convnext_base --epochs 300 -d cifar10 --n_shots 100 --lr 0.001 --wd 0.1 --ckpt ./checkpoints/ghn2_imagenet.pt --opt adamw --init orth --imsize 32 --beta 3e-5 --layer 94`.
+Multiple warnings will be printed that some layers of ConvNeXt are not supported by GHNs, which is intended.
+
+Below are the commands to reproduce the original (NeurIPS 2021) results.
 
 ### 100-shot CIFAR-10
 

--- a/examples/torch_models.py
+++ b/examples/torch_models.py
@@ -11,7 +11,9 @@ The script predicts parameters for the networks and evaluates them on CIFAR-10 o
 
 Example:
 
-    python examples/torch_models.py imagenet resnet50
+    1. python examples/torch_models.py imagenet resnet50
+
+    2. python examples/torch_models.py cifar10 convnext_base
 
 """
 

--- a/experiments/sgd/train_net.py
+++ b/experiments/sgd/train_net.py
@@ -27,6 +27,7 @@ Example:
 import torch
 import torchvision
 import torch.utils
+import time
 import os
 from ppuda.config import init_config
 from ppuda.vision.loader import image_loader
@@ -45,7 +46,8 @@ def main():
     is_imagenet = args.dataset == 'imagenet'
     train_queue, valid_queue, num_classes = image_loader(dataset=args.dataset,
                                                          data_dir=args.data_dir,
-                                                         test=True,
+                                                         test=not args.val,
+                                                         im_size=args.imsize,
                                                          load_train_anyway=True,
                                                          batch_size=args.batch_size,
                                                          test_batch_size=args.test_batch_size,
@@ -56,6 +58,12 @@ def main():
                                                          noise=args.noise,
                                                          n_shots=args.n_shots)
 
+    if args.val:
+        test_queue = image_loader(dataset=args.dataset,
+                                  data_dir=args.data_dir,
+                                  test=True,
+                                  im_size=args.imsize,
+                                  test_batch_size=args.test_batch_size)[1]
 
     assert args.arch is not None, 'architecture genotype/index must be specified'
 
@@ -157,6 +165,11 @@ def main():
         infer(model.eval(), valid_queue, verbose=True)
 
         scheduler.step()
+
+    if args.val:
+        infer(model.eval(), test_queue, verbose=True)
+
+    print('\ndone at {}!'.format(time.strftime('%Y%m%d-%H%M%S')))
 
 if __name__ == '__main__':
     main()

--- a/experiments/sgd/train_net.py
+++ b/experiments/sgd/train_net.py
@@ -104,7 +104,7 @@ def main():
                  orth=args.init.lower() == 'orth',
                  beta=args.beta,
                  layer=args.layer,
-                 max_sz=64,
+                 max_sz=0,
                  verbose=args.debug > 1)
 
     model = model.train().to(args.device)

--- a/experiments/sgd/train_net.py
+++ b/experiments/sgd/train_net.py
@@ -112,7 +112,6 @@ def main():
                  orth=args.init.lower() == 'orth',
                  beta=args.beta,
                  layer=args.layer,
-                 max_sz=0,
                  verbose=args.debug > 1)
 
     model = model.train().to(args.device)

--- a/experiments/train_ghn.py
+++ b/experiments/train_ghn.py
@@ -66,7 +66,7 @@ def main():
 
 
     ghn = GHN(**config,
-              debug_level=args.debug).to(args.device)
+              debug_level=0).to(args.device)
 
     if state_dict is not None:
         ghn.load_state_dict(state_dict['state_dict'])
@@ -125,7 +125,7 @@ def main():
                     for nets_args in graphs.net_args:
                         net = Network(is_imagenet_input=is_imagenet,
                                       num_classes=num_classes,
-                                      compress_params=True,
+                                      light=True,
                                       **nets_args)
                         nets_torch.append(net)
 

--- a/experiments/train_ghn_stable.py
+++ b/experiments/train_ghn_stable.py
@@ -1,0 +1,68 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+A wrapper to automatically restart training GHNs from the last saved checkpoint,
+e.g. in the case of CUDA OOM or nan loss that can frequently occur due to sampling training architectures.
+
+Example:
+
+    # To train GHN-2 on CIFAR-10:
+    python experiments/train_ghn_stable.py experiments/train_ghn.py -m 8 -n -v 50 --ln --name ghn2-cifar10
+
+"""
+
+
+import os
+import sys
+from subprocess import PIPE, run
+
+args = sys.argv[1:]
+ckpt_args = None
+attempts = 0
+
+while attempts < 100:  # let's allow for resuming this job 100 times
+
+    attempts += 1
+    print('\nrunning the script time #%d with args:' % attempts, args, ckpt_args, '\n')
+
+    result = run(['python'] + args + ([] if ckpt_args is None else ckpt_args),
+                 stderr=PIPE, text=True)
+
+    print('script returned:', result)
+    print('\nreturned code:', result.returncode)
+
+
+    if result.returncode != 0:
+
+        print('Script failed!')
+
+        print('\nERROR:', result.stderr)
+
+        if result.returncode == 2 and result.stderr.find('[Errno 2] No such file or directory') >= 0:
+            print('\nRun this script as `python experiments/train_ghn_stable.py experiments/train_ghn.py [args]`\n')
+            break
+
+        elif result.stderr.find('RuntimeError') < 0:
+            print('\nPlease fix the above printed error and restart the script\n')
+            break
+
+        print('restarting the script')
+        n1 = result.stderr.find('use this ckpt for resuming the script:')
+        if n1 >= 0:
+            n1 = result.stderr[n1:].find(':') + n1
+            n2 = result.stderr[n1:].find('\n') + n1
+            ckpt = result.stderr[n1 + 2 : n2]
+            print('parsed path:', ckpt, 'exists:', os.path.exists(ckpt))
+            if os.path.exists(ckpt):
+                ckpt_args = ['--ckpt', ckpt]
+            else:
+                print('saved checkpoint file is missing, will be starting from scratch')
+        else:
+            print('no saved checkpoint found')
+        continue
+    else:
+        break

--- a/ppuda/config.py
+++ b/ppuda/config.py
@@ -165,6 +165,7 @@ def init_config(mode='eval'):
                                 help='standard deviation of the Gaussian noise added to parameters')
             parser.add_argument('--imsize', type=int, default=224 if is_imagenet else 32,
                                 choices=[32, 224], help='image size used to train and eval models')
+            parser.add_argument('--val', action='store_true', default=False, help='evaluate on the validation set')
 
     args = parser.parse_args()
 

--- a/ppuda/deepnets1m/graph.py
+++ b/ppuda/deepnets1m/graph.py
@@ -785,5 +785,7 @@ try:
     import torchvision
     MODULES[torchvision.models.convnext.LayerNorm2d] = MODULES[nn.LayerNorm]
     # MODULES[torchvision.models.convnext.CNBlock] = MODULES[nn.LayerNorm]
+    # we can pretend that layer_scale in CNBlock is the same as LayerNorm and this way predict all ConvNeXt parameters,
+    # but this does not have benefits in fine-tuning
 except Exception as e:
     print(e, 'convnext requires torchvision >= 0.12, current version is ', torchvision.__version__)

--- a/ppuda/deepnets1m/light_ops.py
+++ b/ppuda/deepnets1m/light_ops.py
@@ -1,0 +1,177 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Light weighted version of common PyTorch modules to speed up frequent creation of networks and training GHNs.
+These modules should only be used for training GHNs as their functionality in other cases is not tested.
+
+Example of creating 1000 convolutional layers showing 4x speed up of using Conv2dLight
+
+>>> start = time.time(); len([Conv2d(16,16,1) for i in range(1000)]); time.time() - start
+1000
+0.08254384994506836
+>>> start = time.time(); len([Conv2dLight(16,16,1) for i in range(1000)]); time.time() - start
+1000
+0.0217587947845459
+
+"""
+
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numbers
+from collections import OrderedDict
+from typing import Union, Optional, Dict
+from torch.nn.modules.conv import _pair
+from torch.nn.common_types import _size_2_t
+
+
+class ModuleLight(nn.Module):
+    def __init__(self):
+        super(ModuleLight, self).__init__()
+
+    def __setattr__(self, name: str, value: Union[torch.Tensor, 'Module']) -> None:
+        if isinstance(value, (list, torch.Tensor, nn.Parameter)) or (name in ['weight', 'bias'] and value is None):
+            self._parameters[name] = tuple(value) if isinstance(value, list) else value
+        else:
+            object.__setattr__(self, name, value)
+
+    def to(self, *args, **kwargs):
+        return None
+
+    def reset_parameters(self) -> None:
+        return None
+
+
+class Conv2dLight(ModuleLight):
+
+    def __init__(self, in_channels: int,
+        out_channels: int,
+        kernel_size: _size_2_t,
+        stride: _size_2_t = 1,
+        padding: Union[str, _size_2_t] = 0,
+        dilation: _size_2_t = 1,
+        groups: int = 1,
+        bias: bool = True,
+        padding_mode: str = 'zeros',  # TODO: refine this type
+        device=None,
+        dtype=torch.bool):
+
+        super(Conv2dLight, self).__init__()
+
+        self._parameters: Dict[str, Optional[nn.Parameter]] = OrderedDict()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = _pair(kernel_size)
+        self.stride = _pair(stride)
+        self.padding = padding if isinstance(padding, str) else _pair(padding)
+        self.dilation = _pair(dilation)
+        self.groups = groups
+        self.padding_mode = padding_mode
+        self.weight = [out_channels, in_channels // groups, *self.kernel_size]
+        if bias:
+            self.bias = [out_channels]
+        else:
+            self.bias = None
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.conv2d(input, self.weight, self.bias, self.stride,
+                        self.padding, self.dilation, self.groups)
+
+
+class LinearLight(ModuleLight):
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True,
+                 device=None, dtype=torch.bool):
+        super(LinearLight, self).__init__()
+        self._parameters: Dict[str, Optional[nn.Parameter]] = OrderedDict()
+
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.weight = [out_features, in_features]
+        if bias:
+            self.bias = [out_features]
+        else:
+            self.bias = None
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.linear(input, self.weight, self.bias)
+
+
+class LayerNormLight(ModuleLight):
+
+    def __init__(self, normalized_shape: int, eps: float = 1e-5, elementwise_affine: bool = True,
+                 device=None, dtype=None) -> None:
+        super(LayerNormLight, self).__init__()
+
+        if isinstance(normalized_shape, numbers.Integral):
+            normalized_shape = (normalized_shape,)  # type: ignore[assignment]
+
+        self.normalized_shape = tuple(normalized_shape)  # type: ignore[arg-type]
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        assert elementwise_affine
+        self.weight = list(normalized_shape)
+        self.bias = list(normalized_shape)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.layer_norm(
+            input, self.normalized_shape, self.weight, self.bias, self.eps)
+
+
+class BatchNorm2dLight(ModuleLight):
+
+    def __init__(self, num_features,
+        eps=1e-5,
+        momentum=0.1,
+        affine=True,
+        track_running_stats=False,
+        device=None,
+        dtype=None
+    ):
+        super(BatchNorm2dLight, self).__init__()
+        self.num_features = num_features
+        self.eps = eps
+        self.momentum = momentum
+        self.affine = affine
+        self.track_running_stats = track_running_stats
+
+        assert affine and not track_running_stats, 'assumed affine and that running stats is not updated'
+        self.running_mean = None
+        self.running_var = None
+        self.num_batches_tracked = None
+
+        self.weight = [num_features]
+        self.bias = [num_features]
+
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+
+        if self.momentum is None:
+            exponential_average_factor = 0.0
+        else:
+            exponential_average_factor = self.momentum
+
+        if self.training:
+            bn_training = True
+        else:
+            bn_training = (self.running_mean is None) and (self.running_var is None)
+
+        return F.batch_norm(
+            input,
+            self.running_mean
+            if not self.training or self.track_running_stats
+            else None,
+            self.running_var if not self.training or self.track_running_stats else None,
+            self.weight,
+            self.bias,
+            bn_training,
+            exponential_average_factor,
+            self.eps,
+        )

--- a/ppuda/deepnets1m/net.py
+++ b/ppuda/deepnets1m/net.py
@@ -356,7 +356,8 @@ def named_layered_modules(model):
     layers = model._n_cells if hasattr(model, '_n_cells') else 1
     layered_modules = [[] for _ in range(layers)]
     for module_name, m in model.named_modules():
-        is_w = hasattr(m, 'weight') and m.weight is not None
+        is_layer_scale = hasattr(m, 'layer_scale') and m.layer_scale is not None
+        is_w = (hasattr(m, 'weight') and m.weight is not None) or is_layer_scale
         is_b = hasattr(m, 'bias') and m.bias is not None
 
         if is_w or is_b:
@@ -365,7 +366,9 @@ def named_layered_modules(model):
             cell_ind = get_cell_ind(module_name, layers)
             if is_w:
                 layered_modules[cell_ind].append(
-                    {'param_name': module_name + '.weight', 'module': m, 'is_w': True, 'sz': m.weight.shape})
+                    {'param_name': module_name + ('.layer_scale' if is_layer_scale else '.weight'),
+                     'module': m, 'is_w': True,
+                     'sz': (m.layer_scale if is_layer_scale else m.weight).shape})
             if is_b:
                 layered_modules[cell_ind].append(
                     {'param_name': module_name + '.bias', 'module': m, 'is_w': False, 'sz': m.bias.shape})

--- a/ppuda/deepnets1m/ops.py
+++ b/ppuda/deepnets1m/ops.py
@@ -45,6 +45,11 @@ def parse_op_ks(op):
 
 
 NormLayers = [nn.BatchNorm2d, nn.LayerNorm]
+try:
+    import torchvision
+    NormLayers.append(torchvision.models.convnext.LayerNorm2d)
+except Exception as e:
+    print(e, 'convnext requires torchvision >= 0.12, current version is ', torchvision.__version__)
 
 
 def get_norm_layer(norm, C):

--- a/ppuda/ghn/decoder.py
+++ b/ppuda/ghn/decoder.py
@@ -10,8 +10,10 @@ Decoders to predict 1D-4D parameter tensors given node embeddings.
 """
 
 
+import torch
 import numpy as np
 import torch.nn as nn
+import torch.nn.functional as F
 from .mlp import MLP
 from .layers import get_activation
 
@@ -27,37 +29,65 @@ class ConvDecoder(nn.Module):
         assert len(hid) > 0, hid
         self.out_shape = out_shape
         self.num_classes = num_classes
-        self.fc = nn.Sequential(nn.Linear(in_features,
-                                          hid[0] * np.prod(out_shape[2:])),
-                                nn.ReLU())
+
+        ch_prod = out_shape[0] * out_shape[1]
+        spatial_prod = out_shape[2] * out_shape[3]
+        out_features = hid[0] * spatial_prod
+
+        self.fc = nn.Sequential(nn.Linear(in_features, out_features),
+                                get_activation('relu'))
+        self.register_buffer('cols_1d', torch.arange(0, out_features).view(hid[0], out_shape[2], out_shape[3]),
+                             persistent=False)
+        self.register_buffer('cols_4d', torch.arange(0, ch_prod),
+                             persistent=False)
 
         conv = []
         for j, n_hid in enumerate(hid):
-            n_out = np.prod(out_shape[:2]) if j == len(hid) - 1 else hid[j + 1]
+            n_out = ch_prod if j == len(hid) - 1 else hid[j + 1]
             conv.extend([nn.Conv2d(n_hid, n_out, 1),
                          get_activation(None if j == len(hid) - 1 else 'relu')])
 
         self.conv = nn.Sequential(*conv)
         self.class_layer_predictor = nn.Sequential(
-            nn.ReLU(),
+            get_activation('relu'),
             nn.Conv2d(out_shape[0], num_classes, 1))
 
 
-    def forward(self, x, max_shape=(1,1), class_pred=False):
+    def forward(self, x, max_shape=(1,1,1,1), class_pred=False):
 
         N = x.shape[0]
-        x = self.fc(x).view(N, -1, *self.out_shape[2:])  # N,128,11,11
-        out_shape = self.out_shape
-        if sum(max_shape) > 0:
-            x = x[:, :, :max_shape[0], :max_shape[1]]
-            out_shape = (out_shape[0], out_shape[1], max_shape[0], max_shape[1])
+        if sum(max_shape[2:]) < sum(self.out_shape[2:]) and len(self.fc) == 2:
+            ind = self.cols_1d[:, :max_shape[2], :max_shape[3]].flatten()
+            x = self.fc[1](F.linear(x, self.fc[0].weight[ind],
+                                    self.fc[0].bias[ind]).view(N, -1, max_shape[2], max_shape[3]))  # N,128,a,b
+        else:
+            x = self.fc(x).view(N, -1, *self.out_shape[2:])[:, :, :max_shape[2], :max_shape[3]]  # N,128,11,11
 
-        x = self.conv(x).view(N, *out_shape)  # N, out, in, h, w
+        out_shape = (*self.out_shape[:2], min(self.out_shape[2], max_shape[2]), min(self.out_shape[3], max_shape[3]))
+
+        if (max_shape[1] <= out_shape[1] // 2 or (max_shape[0] < out_shape[0] and not class_pred)) and len(self.conv) == 4:
+            x = self.conv[1](self.conv[0](x)) # N, 256, h, w
+            if max_shape[1] < out_shape[1] and max_shape[1] % 3 == 0:
+                n_in = max_shape[1] // 3 * 4
+            else:
+                n_in = min(max_shape[1], out_shape[1])
+
+            n_out = out_shape[0] if class_pred else min(out_shape[0], max_shape[0])
+            ind = self.cols_4d[:n_out * out_shape[1]]
+            if n_in < out_shape[1]:
+                ind = ind.reshape(-1, n_in)[::out_shape[1] // n_in].flatten()
+
+            x = self.conv[3](F.conv2d(x, self.conv[2].weight[ind], self.conv[2].bias[ind]))
+
+            x = x.reshape(N, n_out, n_in, *out_shape[2:])[:, :, :min(out_shape[1], max_shape[1])]
+            if min(max_shape[2:]) > min(out_shape[2:]):
+                x = x.repeat((1, 1, 1, 2, 2))
+        else:
+            x = self.conv(x).view(N, out_shape[0], -1, *out_shape[2:])  # N, out, in, h, w
 
         if class_pred:
             x = self.class_layer_predictor(x[:, :, :, :, 0])  # N, num_classes, 64, 1
             x = x[:, :, :, 0]  # N, num_classes, 64
-
         return x
 
 
@@ -82,13 +112,13 @@ class MLPDecoder(nn.Module):
             nn.Linear(hid[0], num_classes * out_shape[0]))
 
 
-    def forward(self, x, max_shape=(1,1), class_pred=False):
+    def forward(self, x, max_shape=(1,1,1,1), class_pred=False):
         if class_pred:
             x = list(self.mlp.fc.children())[0](x)  # shared first layer
             x = self.class_layer_predictor(x)  # N, 1000, 64, 1
             x = x.view(x.shape[0], self.num_classes, self.out_shape[1])
         else:
             x = self.mlp(x).view(-1, *self.out_shape)
-            if sum(max_shape) > 0:
-                x = x[:, :, :, :max_shape[0], :max_shape[1]]
+            if sum(max_shape[2:]) > 0:
+                x = x[:, :, :, :max_shape[2], :max_shape[3]]
         return x

--- a/ppuda/ghn/layers.py
+++ b/ppuda/ghn/layers.py
@@ -92,6 +92,8 @@ class ShapeEncoder(nn.Module):
                 sz = (sz[0], 1)
             if len(sz) == 2:
                 sz = (sz[0], sz[1], 1, 1)
+            if len(sz) == 3:
+                sz = (sz[0], sz[1], sz[2], 1)
             assert len(sz) == 4, sz
 
             if not predict_class_layers and params_map[node_ind][1] in ['cls_w', 'cls_b']:

--- a/ppuda/ghn/nn.py
+++ b/ppuda/ghn/nn.py
@@ -182,7 +182,7 @@ class GHN(nn.Module):
         param_groups, params_map = self._map_net_params(graphs, nets_torch, self.debug_level > 0)
 
         if self.debug_level or not self.training:
-            n_params_true = sum([capacity(net)[1] for net in (nets_torch if isinstance(nets_torch, list) else [nets_torch])])
+            n_params_true = sum([capacity(net, is_grad=False)[1] for net in (nets_torch if isinstance(nets_torch, list) else [nets_torch])])
             if self.debug_level > 1:
                 print('\nnumber of learnable parameter tensors: {}, total number of parameters: {}'.format(
                     valid_ops, n_params_true))
@@ -457,7 +457,7 @@ class GHN(nn.Module):
         is_layer_scale = hasattr(module, 'layer_scale') and module.layer_scale is not None
         key = ('layer_scale' if is_layer_scale else 'weight' ) if is_w else 'bias'
         target_param = getattr(module, key)
-        sz_target = target_param.shape
+        sz_target = tuple(target_param) if isinstance(target_param, (list, tuple)) else target_param.shape
         if self.training:
             module.__dict__[key] = tensor  # set the value avoiding the internal logic of PyTorch
             # update parameters, so that named_parameters() will return tensors

--- a/ppuda/utils/__init__.py
+++ b/ppuda/utils/__init__.py
@@ -7,3 +7,4 @@
 from .darts_utils import *
 from .trainer import *
 from .utils import *
+from .init import *

--- a/ppuda/utils/init.py
+++ b/ppuda/utils/init.py
@@ -86,7 +86,7 @@ def init(model, orth=True, beta=0, layer=0, max_sz=0, verbose=False):
                 if verbose:
                     print_stats(weight, ev_max, m1, m2, 'orthogonalization: ')
 
-        elif len(sz) == 1 and (not skip_shallow or (skip_shallow and sz[0] > max_sz and layer_2d >= layer)):
+        elif len(sz) == 1 and beta > 0 and (not skip_shallow or (skip_shallow and sz[0] > max_sz and layer_2d >= layer)):
             # Assume batch/layer norm follows convolution so use statistics from the preceding convolution layer
             weight[max_sz:].data += beta * std_r * torch.randn_like(weight[max_sz:])
 

--- a/ppuda/utils/init.py
+++ b/ppuda/utils/init.py
@@ -32,24 +32,21 @@ def init(model, orth=True, beta=0, layer=0, max_sz=0, verbose=False):
         return model
 
     print(
-        '\npostprocessing parameters: orth={} \t beta={} \t layer={} \t max_sz={}\n'.format(
+        '\npostprocessing parameters: orth={} \t beta={} \t layer={} \t max_sz={}'.format(
             orth, beta, layer, max_sz
         ))
 
-    skip_shallow = model.__module__.startswith('torchvision.models.convnext')   # do not add noise to layers before the specified layer
-
     layer_2d = 0  # layer counter
 
-    has_weight = lambda m: hasattr(m, 'weight') and m.weight is not None and m.weight.dim() > 0
-    has_2dplus_weight = lambda m: has_weight(m) and m.weight.dim() >= 2
-    num_2d_layers = len([m for m in model.modules() if has_2dplus_weight(m)])
+    has_2d_weight = lambda m: hasattr(m, 'weight') and m.weight is not None and m.weight.dim() >= 2
+    num_2d_layers = len([m for m in model.modules() if has_2d_weight(m)])
 
     for module in model.modules():
 
-        if not has_weight(module):
-            continue  # skip the layers that do not have the 'weight' attribute
+        if not has_2d_weight(module):
+            continue  # skip the layers that do not have the 'weight' attribute with at least 2 dimensions
 
-        layer_2d += has_2dplus_weight(module)
+        layer_2d += 1
 
         if layer_2d == num_2d_layers:
             continue  # skip the last classification layer
@@ -57,55 +54,39 @@ def init(model, orth=True, beta=0, layer=0, max_sz=0, verbose=False):
         weight = module.weight.data
         sz = weight.shape
 
-        ev_max = get_eigs(weight).max().item()  # for statistics
-        m1, m2 = weight.min().item(), weight.max().item()  # for statistics
+        if layer_2d >= layer and max(sz[:2]) > max_sz:
 
-        def print_stats(w, ev_max, m1, m2, name):
-            print(
-                '{}\t layer = {} \t shape = {} \t{} min-max before:after = {:.2f}-{:.2f} : {:.2f}-{:.2f} \t{}'
-                ' max eig before:after = {:.2f} \t: {:.2f}'.format(
-                    name, layer_2d, tuple(w.shape), '\t' if w.dim() <= 2 else '',
-                    m1, m2, w.min().item(), w.max().item(), '\t' if w.min() > 0 else '',
-                    ev_max, get_eigs(w).max().item()))
+            if verbose:
+                ev_max = get_eigs(weight).max().item()  # to print statistics
+                m1, m2 = weight.min().item(), weight.max().item()  # to print statistics
 
-        if has_2dplus_weight(module):
+                def print_stats(w, ev_max, m1, m2, name):
+                    print(
+                        '{}\t layer = {} \t shape = {} \t{} min-max before:after = {:.2f}-{:.2f} : {:.2f}-{:.2f} \t{}'
+                        ' max eig before:after = {:.2f} \t: {:.2f}'.format(
+                            name, layer_2d, tuple(w.shape), '\t' if w.dim() <= 2 else '',
+                            m1, m2, w.min().item(), w.max().item(), '\t' if w.min() > 0 else '',
+                            ev_max, get_eigs(w).max().item()))
 
             if beta > 0:
                 std_r = get_corr(weight).std()
-                if beta > 0 and (not skip_shallow or (skip_shallow and max(sz[:2]) > max_sz and layer_2d >= layer)):
-                    noise = beta * std_r * torch.randn_like(weight[max_sz:, max_sz:])
-                    weight[max_sz:, max_sz:].data += noise
+                noise = beta * std_r * torch.randn_like(weight[max_sz:, max_sz:])
+                weight[max_sz:, max_sz:].data += noise
 
-                    if verbose:
-                        print_stats(weight, ev_max, m1, m2, 'add noise to conv-w: ')
+                if verbose:
+                    print_stats(weight, ev_max, m1, m2, 'add noise to conv-w: ')
 
-                    # Can add noise to bias, but was not found beneficial
-
-            if orth and max(sz[:2]) > max_sz and layer_2d >= layer:
+            if orth:
                 weight = orthogonalize(weight)
                 if verbose:
                     print_stats(weight, ev_max, m1, m2, 'orthogonalization: ')
 
-        elif len(sz) == 1 and beta > 0 and (not skip_shallow or (skip_shallow and sz[0] > max_sz and layer_2d >= layer)):
-            # Assume batch/layer norm follows convolution so use statistics from the preceding convolution layer
-            weight[max_sz:].data += beta * std_r * torch.randn_like(weight[max_sz:])
-
-            if verbose:
-                print_stats(weight, ev_max, m1, m2, 'add noise to norm-w: ')
-
-            if hasattr(module, 'bias') and module.bias is not None:
-                ev_max = get_eigs(module.bias).max().item()  # for statistics
-                m1, m2 = module.bias.min().item(), module.bias.max().item()  # for statistics
-                module.bias[max_sz:].data += beta * std_r * torch.randn_like(module.bias[max_sz:])
-
-                if verbose:
-                    print_stats(module.bias, ev_max, m1, m2, 'add noise to norm-b: ')
+        # Can add noise to batch/layer norm layers and conv/linear biases, but was not found to be beneficial
 
         assert weight.shape == module.weight.shape, (weight.shape, module.weight.shape)
         module.weight.data = weight
 
-    if verbose:
-        print('\ndone initialization!\n')
+    print('done postprocessing!\n')
 
     return model
 

--- a/ppuda/utils/utils.py
+++ b/ppuda/utils/utils.py
@@ -196,12 +196,13 @@ def set_seed(seed, only_torch=False):
     torch.cuda.manual_seed_all(seed)
 
 
-def capacity(model):
+def capacity(model, is_grad=True):
     c, n = 0, 0
     for name, p in model.named_parameters():
-        if p.requires_grad:
+        if not is_grad or (is_grad and p.requires_grad):
             c += 1
-            n += np.prod(p.shape)
+            sz = p if isinstance(p, (tuple, list)) else p.shape
+            n += np.prod(sz)
     return c, int(n)
 
 


### PR DESCRIPTION
# Training times 

Implementation of some steps in the forward pass of GHNs is improved to speed up the training time of GHNs without altering their overall behavior. 

Speed is measured on NVIDIA A100-40GB in terms of seconds per training iteration on ImageNet (averaged for the first 50 iterations). 4xA100 are used for meta-batch size (bm) = 8. Measurements can be noisy because of potentially other users using some computational resources of the same cluster node.

| Model | AMP* | Current version | This PR  | Estimated total speed up for 300/150 epochs**
|---|:---------:|:---------:|:------------------------:|:------------------------:|
| MLP with bm = 1 | ✘ |  0.30 sec/iter   | 0.22 sec/iter     |  5.0 days -> **3.7** days
| MLP with bm = 8  | ✔ | 1.64 sec/iter   | 1.01 sec/iter     |  13.7 days -> **8.4** days
| GHN-2 with bm = 1  | ✘ | 0.77 sec/iter   | 0.70 sec/iter    |  12.9 days -> **11.7** days
| GHN-2 with bm = 8 | ✔ | 3.80 sec/iter   |  3.08 sec/iter    |  31.7 days -> **25.7** days
| GHN-2 with bm = 8 | ✘ | 3.45 sec/iter   |  2.80 sec/iter    |  28.8 days -> **23.4** days

- *Automatic Mixed Precision (enabled by the `--amp` argument in the code)
- **To estimate the total training time, 300 epochs is used for bm=1 and 150 epochs is used for bm=8 (according to the paper).

# Fine-tuning and ConvNeXt support

According to the report ([Pretraining a Neural Network before Knowing Its Architecture](https://arxiv.org/abs/2207.10049)) showing improved fine-tuning results, the following arguments are added to the code: `--opt`, `--init`, `--imsize`, `--beta`, `--layer` and file [ppuda/utils/init.py](ppuda/utils/init.py) with initialization functions. Also argument `--val` is added to enable evaluation on the validation data rather than testing data during training.

- For example, to obtain fine-tuning results of `GHN-orth` for **ResNet-50** according to the report:
`python experiments/sgd/train_net.py --val --split predefined --arch 0 --epochs 300 -d cifar10 --n_shots 100 --lr 0.01 --wd 0.01 --ckpt ./checkpoints/ghn2_imagenet.pt --opt sgd --init orth --imsize 32 --beta 3e-5 --layer 37`

- For **[ConvNeXt-Base](https://arxiv.org/abs/2201.03545)**:
`python experiments/sgd/train_net.py --val --arch convnext_base -b 48 --epochs 300 -d cifar10 --n_shots 100 --lr 0.001 --wd 0.1 --ckpt ./checkpoints/ghn2_imagenet.pt --opt adamw --init orth --imsize 32 --beta 3e-5 --layer 94`.
Multiple warnings will be printed that some layers (layer_scale) of ConvNeXt are not supported by GHNs, which is intended. 

A simple example to try parameter prediction for ConvNeXt is to run:

`python examples/torch_models.py cifar10 convnext_base` 

# Code correctness

To make sure that the evaluation results (classification accuracies of predicted parameters) reported in the paper are the same as in this PR, the GHNs were evaluated on selected architectures and the same results were obtained (see the table below).

| Model |   ResNet-50   | ViT | Test Architecture (index in the test split) |
|---|:---------:|:------------------------:|:------------------------:|
| GHN-2-CIFAR-10 (top 1 acc) | 58.6% | 11.4% | 77.1% (210) |
| GHN-2-ImageNet (top5 acc) | 5.3% | 4.4% | 48.3% (85)  |

To further confirm the correctness of the updated code, the training loss and top1 accuracy of training GHN-2 on CIFAR-10 for 3 epochs are reported in the table below. The command used in this benchmark is: `python experiments/train_ghn.py -m 8 -n -v 50 --ln`.

| Version |   Epoch 1  |  Epoch 2 | Epoch 3 |
|---|:---------:|:------------------------:|:------------------------:|
| Current version | loss=2.41, top1=17.23 |  loss=2.02, top1=20.62 | loss=1.94, top1=24.56 |
| This PR |  loss=2.51, top1=17.58 | loss=2.01, top1=21.62 | loss=1.90, top1=25.88 |

These results can be noisy because of several factors like random batches, initialization of GHN, etc. 

# Other

Python script [experiments/train_ghn_stable.py](experiments/train_ghn_stable.py) is added to automatically resume training GHNs from the last saved checkpoint (if any) if the run failed for some reason (e.g. OOM, nan loss, etc.).
Now instead of running `python experiments/train_ghn.py -m 8 -n -v 50 --ln` one can use
`python experiments/train_ghn_stable.py experiments/train_ghn.py -m 8 -n -v 50 --ln`.